### PR TITLE
Use `return` to set deny_reason in ValidatingRule

### DIFF
--- a/examples/validatingrule.yaml
+++ b/examples/validatingrule.yaml
@@ -10,5 +10,5 @@ spec:
     operations: ["CREATE"]
   code: |
     if request.name:sub(-4) ~= "-uwu" then
-      deny_reason = "That name is not cute."
+      return "That name is not cute."
     end

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -107,16 +107,12 @@ async fn validate(
             )
             .map_err(Error::SetGlobalAdmissionRequestValue)?;
 
-        lua_ctx
+        let deny_reason = lua_ctx
             .load(&vr.spec.code)
             .set_name("rule code")
             .map_err(Error::SetLuaCodeName)?
-            .exec()
+            .eval()
             .map_err(Error::LuaExec)?;
-
-        let deny_reason = globals
-            .get::<_, Option<String>>("deny_reason")
-            .map_err(Error::GetDenyReasonValue)?;
 
         Ok(deny_reason)
     })?;


### PR DESCRIPTION
`exec` 대신 `eval` 을 쓰면 return 문을 쓸 수 있더라구요! ValidatingRule 사용성이 대폭 상승할 것으로 기대됩니다.

MutatingRule에도 적용하지 않은 이유는, MutatingRule에서는 `deny_reason` 과 `patch` 라는 두 변수를 얻어내야하는데, 이를 return 문으로 어떻게 풀어낼지가 고민입니다...