### PR TITLE
Use `return` to set deny_reason and patch in MutatingRule

### DIFF
--- a/examples/mutatingrule.yaml
+++ b/examples/mutatingrule.yaml
@@ -11,5 +11,5 @@ spec:
   code: |
     if request.name:sub(-4) ~= "-uwu" then
       new_name = request.name .. "-uwu"
-      patch = {{op="replace", path="/metadata/name", value=new_name}}
+      return nil, {{op="replace", path="/metadata/name", value=new_name}}
     end


### PR DESCRIPTION
#3 과 마찬가지로 MutatingRule에서도 `return` 문으로 `deny_reason` 과 `patch` 를 돌려주게 합니다. [Multiple Results](https://www.lua.org/pil/5.1.html) 라는 것을 이용하는데, 어떤 것이 `deny_reason` 인지가 헷갈리긴 하지만 이건 매뉴얼을 잘 써서 풀 수 있을 것 같아요.