### PR TITLE
Use Recreate strategy for controller deployment

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       {{- include "checkpoint.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
contoller pod이 두 대가 동시에 떠 있으면 같은 리소스에 대해 서로 reconcile을 하려고 하는 문제가 있습니다. 이를 방지하기 위해 deployment의 strategy를 Recreate로 변경합니다.