### PR TITLE
Log object name only when reconcilation succeeds

### DIFF
--- a/src/bin/controller.rs
+++ b/src/bin/controller.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
             )
             .for_each(|res| async move {
                 match res {
-                    Ok(object) => tracing::info!(?object, "reconciled"),
+                    Ok((object, _)) => tracing::info!(name = object.name, "reconciled"),
                     Err(error) => tracing::error!(%error, "reconcile failed"),
                 }
             }),


### PR DESCRIPTION
It is too verbose to log all objects with Debug formating. Just log the object name only when reconciliation succeeds.