### PR TITLE
Move envy logic to config module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.14",
+ "stopper",
  "thiserror",
  "tokio",
  "tower-http",
@@ -322,6 +323,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cxx"
@@ -486,6 +496,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +578,21 @@ name = "futures-io"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1291,6 +1325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1861,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "stopper"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4573bf2456e356934de15c7151d1c9fc8873e8866a7c2b5e0bb20f8244bd0073"
+dependencies = [
+ "futures-lite",
+ "pin-project",
+ "waker-set",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,6 +2213,22 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "waker-set"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e958152c46345e1af5c61812030ac85200573a0b384c137e83ce2c01ac4bc07"
+dependencies = [
+ "crossbeam-utils",
+ "slab",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ secrecy = "0.8.0"
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
 serde_yaml = "0.9.14"
+stopper = "0.2.0"
 thiserror = "1.0.37"
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.3.4", features = ["trace"] }

--- a/src/bin/controller.rs
+++ b/src/bin/controller.rs
@@ -43,7 +43,7 @@ async fn shutdown_signal(shutdown_signal_broadcast_tx: Sender<()>) {
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let config: ControllerConfig = envy::prefixed("CONF_").from_env()?;
+    let config = ControllerConfig::try_from_env()?;
     let kube_config = kube::Config::infer().await?;
     let default_namespace = kube_config.default_namespace.clone();
     let client: kube::Client = kube_config.try_into()?;

--- a/src/bin/webhook.rs
+++ b/src/bin/webhook.rs
@@ -1,5 +1,5 @@
-use std::io;
 use std::path::Path;
+use std::{io, net::SocketAddr};
 
 use anyhow::Result;
 use axum_server::tls_rustls::RustlsConfig;
@@ -92,7 +92,9 @@ async fn main() -> Result<()> {
 
     // Spawn HTTP server
     tracing::info!("starting web server...");
-    axum_server::bind_rustls(config.listen_addr.parse()?, tls_config)
+    let listen_addr: SocketAddr = config.listen_addr.parse()?;
+    tracing::info!("listening at {}...", listen_addr);
+    axum_server::bind_rustls(listen_addr, tls_config)
         .handle(axum_server_handle)
         .serve(http_app.into_make_service())
         .await?;

--- a/src/bin/webhook.rs
+++ b/src/bin/webhook.rs
@@ -4,12 +4,13 @@ use std::{io, net::SocketAddr};
 use anyhow::Result;
 use axum_server::tls_rustls::RustlsConfig;
 use notify::{RecursiveMode, Watcher};
-use tokio::runtime::Runtime;
+use stopper::Stopper;
+use tokio::sync::mpsc;
 
 use checkpoint::config::WebhookConfig;
 
 /// Generate future that awaits shutdown signal
-async fn shutdown_signal(axum_server_handle: axum_server::Handle) {
+async fn shutdown_signal(axum_server_handle: axum_server::Handle, stopper: Stopper) {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
             .await
@@ -35,12 +36,32 @@ async fn shutdown_signal(axum_server_handle: axum_server::Handle) {
     tracing::info!("terminate signal received");
 
     axum_server_handle.graceful_shutdown(Some(std::time::Duration::from_secs(30)));
+    stopper.stop();
 }
 
 async fn reload_config(config: &WebhookConfig, tls_config: &RustlsConfig) -> Result<(), io::Error> {
     tls_config
         .reload_from_pem_file(&config.cert_path, &config.key_path)
         .await
+}
+
+async fn reload_config_loop(
+    mut receiver: mpsc::Receiver<()>,
+    stopper: Stopper,
+    config: WebhookConfig,
+    tls_config: RustlsConfig,
+) {
+    while let Some(Some(())) = stopper.stop_future(receiver.recv()).await {
+        let res = reload_config(&config, &tls_config).await;
+        match res {
+            Ok(_) => {
+                tracing::info!("TLS certificate reloaded");
+            }
+            Err(error) => {
+                tracing::error!(%error, "Failed to reload cert");
+            }
+        }
+    }
 }
 
 #[tokio::main]
@@ -57,22 +78,22 @@ async fn main() -> Result<()> {
     // Prepare TLS config for HTTPS serving
     let tls_config = RustlsConfig::from_pem_file(&config.cert_path, &config.key_path).await?;
 
-    let watcher_tls_config = tls_config.clone();
-    let watcher_config = config.clone();
-    let watcher_async_runtime = Runtime::new().unwrap();
+    let stopper = Stopper::new();
+
+    // Prepare TLS cert reloader
+    let (watcher_sender, watcher_receiver) = mpsc::channel::<()>(10);
+    tokio::spawn(reload_config_loop(
+        watcher_receiver,
+        stopper.clone(),
+        config.clone(),
+        tls_config.clone(),
+    ));
     let mut watcher = notify::recommended_watcher(move |res| {
         tracing::info!("Reloading TLS certificate");
         match res {
             Ok(_) => {
-                let reload_res = watcher_async_runtime
-                    .block_on(reload_config(&watcher_config, &watcher_tls_config));
-                match reload_res {
-                    Ok(_) => {
-                        tracing::info!("TLS certificate reloaded");
-                    }
-                    Err(error) => {
-                        tracing::error!(%error, "Failed to reload cert");
-                    }
+                if watcher_sender.blocking_send(()).is_err() {
+                    tracing::error!("Failed to send cert reload message");
                 }
             }
             Err(error) => {
@@ -85,7 +106,7 @@ async fn main() -> Result<()> {
 
     // Prepare shutdown signal futures
     let axum_server_handle = axum_server::Handle::new();
-    let shutdown_signal_fut = shutdown_signal(axum_server_handle.clone());
+    let shutdown_signal_fut = shutdown_signal(axum_server_handle.clone(), stopper);
     tokio::spawn(async move {
         shutdown_signal_fut.await;
     });

--- a/src/bin/webhook.rs
+++ b/src/bin/webhook.rs
@@ -47,7 +47,7 @@ async fn reload_config(config: &WebhookConfig, tls_config: &RustlsConfig) -> Res
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let config: WebhookConfig = envy::prefixed("CONF_").from_env()?;
+    let config = WebhookConfig::try_from_env()?;
     let kube_config = kube::Config::infer().await?;
     let client: kube::Client = kube_config.try_into()?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,12 @@ pub struct ControllerConfig {
     pub ca_bundle: String,
 }
 
+impl ControllerConfig {
+    pub fn try_from_env() -> Result<Self, envy::Error> {
+        envy::prefixed("CONF_").from_env()
+    }
+}
+
 #[derive(Deserialize, Clone, Debug)]
 pub struct WebhookConfig {
     /// Certificate path for HTTPS
@@ -28,4 +34,10 @@ pub struct WebhookConfig {
 
     #[serde(default = "default_listen_addr")]
     pub listen_addr: String,
+}
+
+impl WebhookConfig {
+    pub fn try_from_env() -> Result<Self, envy::Error> {
+        envy::prefixed("CONF_").from_env()
+    }
 }


### PR DESCRIPTION
Rather than using another tokio Runtime, use an mpsc channel to reload the TLS cert.


And this PR also includes minor improvements.