### PR TITLE
Update image repository

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -95,7 +95,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
 image:
-  repository: ""
+  repository: ghcr.io/devsisters/checkpoint
   pullPolicy: ""
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Note that currently, a user must specify a tag manually because there is no `latest` tag for the image.