### PR TITLE
Fix descriptions, clippy warning, and bug

### DIFF
--- a/helm/templates/customresourcedefinition.yaml
+++ b/helm/templates/customresourcedefinition.yaml
@@ -150,7 +150,7 @@ spec:
                 description: |-
                   The name of ServiceAccount to use to run Lua code.
 
-                  If you want to use `kube_get` or `kube_list` function in Lua code, you must provide ServiceAccount info with this field.
+                  If you want to use `kubeGet` or `kubeList` function in Lua code, you must provide ServiceAccount info with this field.
                 nullable: true
                 properties:
                   name:
@@ -336,7 +336,7 @@ spec:
                 description: |-
                   The name of ServiceAccount to use to run Lua code.
 
-                  If you want to use `kube_get` or `kube_list` function in Lua code, you must provide ServiceAccount info with this field.
+                  If you want to use `kubeGet` or `kubeList` function in Lua code, you must provide ServiceAccount info with this field.
                 nullable: true
                 properties:
                   name:

--- a/src/handler/lua/helper.rs
+++ b/src/handler/lua/helper.rs
@@ -126,9 +126,9 @@ async fn kube_get<'lua>(lua: &'lua Lua, argument: Value<'lua>) -> mlua::Result<V
 
     // Prepare Kubernetes API with or without namespace
     let api = if let Some(namespace) = namespace {
-        Api::<Object<JsonValue, JsonValue>>::namespaced_with(client, &namespace, &ar)
+        Api::<Object<Option<JsonValue>, JsonValue>>::namespaced_with(client, &namespace, &ar)
     } else {
-        Api::<Object<JsonValue, JsonValue>>::all_with(client, &ar)
+        Api::<Object<Option<JsonValue>, JsonValue>>::all_with(client, &ar)
     };
 
     // Get object
@@ -208,9 +208,9 @@ async fn kube_list<'lua>(lua: &'lua Lua, argument: Value<'lua>) -> mlua::Result<
 
     // Prepare Kubernetes API with or without namespace
     let api = if let Some(namespace) = namespace {
-        Api::<Object<JsonValue, JsonValue>>::namespaced_with(client, &namespace, &ar)
+        Api::<Object<Option<JsonValue>, JsonValue>>::namespaced_with(client, &namespace, &ar)
     } else {
-        Api::<Object<JsonValue, JsonValue>>::all_with(client, &ar)
+        Api::<Object<Option<JsonValue>, JsonValue>>::all_with(client, &ar)
     };
 
     // List objects

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -30,7 +30,7 @@ pub enum Error {
     RuleNotFound,
     #[error("Lua app data not found. This is a bug.")]
     LuaAppDataNotFound,
-    #[error("serviceAccount field is not provided. You should provide serviceAccount field in Rule spec if you want to use `kube_get` or `kube_list` function in Lua code.")]
+    #[error("serviceAccount field is not provided. You should provide serviceAccount field in Rule spec if you want to use `kubeGet` or `kubeList` function in Lua code.")]
     ServiceAccountInfoNotProvided,
     #[error("provided ServiceAccount is not found")]
     ServiceAccountNotFound,

--- a/src/types/rule.rs
+++ b/src/types/rule.rs
@@ -62,7 +62,7 @@ pub struct RuleSpec {
 
     /// The name of ServiceAccount to use to run Lua code.
     ///
-    /// If you want to use `kube_get` or `kube_list` function in Lua code, you must provide ServiceAccount info with this field.
+    /// If you want to use `kubeGet` or `kubeList` function in Lua code, you must provide ServiceAccount info with this field.
     pub service_account: Option<ServiceAccountInfo>,
 
     /// Lua code to evaluate when validating request.

--- a/src/types/testcase.rs
+++ b/src/types/testcase.rs
@@ -73,7 +73,7 @@ where
             Self::Object(o) => Ok(o),
             Self::FilePath(path) => {
                 let path = join_or_absolute(base_path, &path);
-                let file = fs::File::open(&path).context("failed to open file")?;
+                let file = fs::File::open(path).context("failed to open file")?;
                 serde_yaml::from_reader(file).context("failed to deserialize file")
             }
         }


### PR DESCRIPTION
- Fix outdated error and spec descriptions
- Fix clippy warning
- Fix bug that `kubeGet` and `kubeList` occur error when fetching object without `spec` field.