### PR TITLE
Reload TLS cert and CA bundle properly

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -43,11 +43,16 @@ spec:
           value: {{ include "checkpoint.fullname" . }}-webhook
         - name: CONF_SERVICE_PORT
           value: "{{ .Values.controller.service.port }}"
-        - name: CONF_CA_BUNDLE
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "checkpoint.fullname" . }}-cert
-              key: ca.crt
+        - name: CONF_CA_BUNDLE_PATH
+          value: /tmp/cert/ca.crt
+        volumeMounts:
+        - name: certs
+          mountPath: /tmp/cert
+          readOnly: true
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ include "checkpoint.fullname" . }}-cert
       {{- with .Values.controller.nodeSelector | default .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/src/bin/controller.rs
+++ b/src/bin/controller.rs
@@ -1,20 +1,28 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use futures_util::stream::StreamExt;
+use futures_util::{
+    future::try_join,
+    stream::{FuturesUnordered, StreamExt, TryStreamExt},
+};
 use k8s_openapi::{
     api::admissionregistration::v1::{
         MutatingWebhookConfiguration, ValidatingWebhookConfiguration,
     },
     ByteString,
 };
-use kube::{api::Api, runtime::Controller};
+use kube::{
+    api::{Api, ListParams, Patch, PatchParams},
+    runtime::Controller,
+    ResourceExt,
+};
+use stopper::Stopper;
 use tokio::sync::{broadcast::Sender, RwLock};
 
 use checkpoint::config::ControllerConfig;
 
 /// Generate future that awaits shutdown signal
-async fn shutdown_signal(shutdown_signal_broadcast_tx: Sender<()>) {
+async fn shutdown_signal(shutdown_signal_broadcast_tx: Sender<()>, stopper: Stopper) {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
             .await
@@ -40,6 +48,74 @@ async fn shutdown_signal(shutdown_signal_broadcast_tx: Sender<()>) {
     tracing::info!("terminate signal received");
 
     let _ = shutdown_signal_broadcast_tx.send(());
+    stopper.stop();
+}
+
+async fn reload_ca_bundle(
+    config: &ControllerConfig,
+    vwc_api: &Api<ValidatingWebhookConfiguration>,
+    mwc_api: &Api<MutatingWebhookConfiguration>,
+    ca_bundle_lock: &RwLock<ByteString>,
+) -> Result<()> {
+    let ca_bundle = tokio::fs::read_to_string(&config.ca_bundle_path).await?;
+    let ca_bundle = k8s_openapi::ByteString(ca_bundle.as_bytes().to_vec());
+
+    {
+        let current_ca_bundle = ca_bundle_lock.read().await;
+        if ca_bundle == *current_ca_bundle {
+            tracing::info!("TLS CA bundle is not changed. Skipping reload...");
+            return Ok(());
+        }
+    }
+
+    {
+        let mut ca_bundle_lock_write = ca_bundle_lock.write().await;
+        *ca_bundle_lock_write = ca_bundle.clone();
+    }
+
+    let vwcs = vwc_api
+        .list(&ListParams::default().labels(checkpoint::reconcile::VALIDATINGRULE_OWNED_LABEL_KEY))
+        .await?
+        .items;
+    let mwcs = mwc_api
+        .list(&ListParams::default().labels(checkpoint::reconcile::MUTATINGRULE_OWNED_LABEL_KEY))
+        .await?
+        .items;
+
+    macro_rules! patch {
+        ($wcs:expr, $api:expr, $manager:literal) => {
+            $wcs.into_iter()
+                .map(|mut wc| {
+                    // Mark WebhookConfiguration to be updated.
+                    // Then the controller watching the WC will reconcile with new CA bundle
+                    let annotations = wc.annotations_mut();
+                    annotations.insert(
+                        checkpoint::reconcile::SHOULD_UPDATE_ANNOTATION_KEY.to_string(),
+                        "true".to_string(),
+                    );
+                    async move {
+                        wc.metadata.managed_fields = None;
+                        $api.patch(
+                            &wc.name_any(),
+                            &PatchParams::apply($manager),
+                            &Patch::Apply(&wc),
+                        )
+                        .await
+                        .map(|_| ())
+                    }
+                })
+                .collect::<FuturesUnordered<_>>()
+                .try_collect::<()>()
+        };
+    }
+
+    let vwcs_patch = patch!(vwcs, vwc_api, "validatingrule.checkpoint.devsisters.com");
+    let mwcs_patch = patch!(mwcs, mwc_api, "mutatingrule.checkpoint.devsisters.com");
+    try_join(vwcs_patch, mwcs_patch).await?;
+
+    tracing::info!("TLS CA bundle reloaded");
+
+    Ok(())
 }
 
 #[tokio::main]
@@ -52,11 +128,12 @@ async fn main() -> Result<()> {
     let client: kube::Client = kube_config.try_into()?;
 
     // Prepare shutdown signal futures
+    let stopper = Stopper::new();
     let (shutdown_signal_broadcast_tx, mut shutdown_signal_broadcast_rx1) =
         tokio::sync::broadcast::channel::<()>(1);
     let mut shutdown_signal_broadcast_rx2 = shutdown_signal_broadcast_tx.subscribe();
     let mut shutdown_signal_broadcast_rx3 = shutdown_signal_broadcast_tx.subscribe();
-    let shutdown_signal_fut = shutdown_signal(shutdown_signal_broadcast_tx);
+    let shutdown_signal_fut = shutdown_signal(shutdown_signal_broadcast_tx, stopper.clone());
     tokio::spawn(async move {
         shutdown_signal_fut.await;
     });
@@ -94,6 +171,33 @@ async fn main() -> Result<()> {
     let vwc_api = Api::<ValidatingWebhookConfiguration>::all(client.clone());
     let mr_api = Api::<checkpoint::types::rule::MutatingRule>::all(client.clone());
     let mwc_api = Api::<MutatingWebhookConfiguration>::all(client.clone());
+
+    // Prepare TLS CA bundle reloader
+    let mut watcher = checkpoint::filewatcher::FileWatcher::new(
+        {
+            let config = config.clone();
+            let ca_bundle = ca_bundle.clone();
+            let vwc_api = vwc_api.clone();
+            let mwc_api = mwc_api.clone();
+            move |_| {
+                let config = config.clone();
+                let ca_bundle = ca_bundle.clone();
+                let vwc_api = vwc_api.clone();
+                let mwc_api = mwc_api.clone();
+                async move {
+                    tracing::info!("Reloading TLS CA bundle");
+                    let res = reload_ca_bundle(&config, &vwc_api, &mwc_api, &ca_bundle).await;
+                    if let Err(error) = res {
+                        tracing::error!(%error, "Failed to reload CA bundle");
+                    }
+                }
+            }
+        },
+        10,
+        stopper,
+    );
+    watcher.watch(config.ca_bundle_path.clone());
+    watcher.spawn()?;
 
     // Spawn ValidatingRule controller
     let vr_controller_handle = tokio::spawn(

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,8 +15,8 @@ pub struct ControllerConfig {
     /// Installed Kubernetes Service port of the checkpoint webhook
     pub service_port: i32,
 
-    /// Base64 encoded PEM CA bundle for the checkpoint webhook
-    pub ca_bundle: String,
+    /// Base64 encoded PEM CA bundle file path for the checkpoint webhook
+    pub ca_bundle_path: PathBuf,
 }
 
 impl ControllerConfig {

--- a/src/filewatcher.rs
+++ b/src/filewatcher.rs
@@ -1,0 +1,67 @@
+use std::{collections::HashSet, future::Future, path::PathBuf};
+
+use anyhow::Result;
+use notify::{RecursiveMode, Watcher};
+use stopper::Stopper;
+
+pub struct FileWatcher<H> {
+    handler: H,
+    buffer: usize,
+    stopper: Stopper,
+    paths: HashSet<PathBuf>,
+}
+
+impl<H> FileWatcher<H> {
+    pub fn new(handler: H, buffer: usize, stopper: Stopper) -> Self {
+        Self {
+            handler,
+            buffer,
+            stopper,
+            paths: Default::default(),
+        }
+    }
+
+    pub fn watch(&mut self, path: PathBuf) {
+        self.paths.insert(path);
+    }
+}
+
+impl<H, F> FileWatcher<H>
+where
+    H: Fn(notify::Event) -> F + Send + Sync + 'static,
+    F: Future + Send,
+{
+    pub fn spawn(self) -> Result<()> {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(self.buffer);
+
+        let mut watcher = notify::recommended_watcher(move |event_res| {
+            let _ = sender.blocking_send(event_res);
+        })?;
+        for path in self.paths {
+            watcher.watch(&path, RecursiveMode::NonRecursive)?;
+        }
+
+        tokio::spawn(async move {
+            while let Some(Some(event_res)) = self.stopper.stop_future(receiver.recv()).await {
+                match event_res {
+                    Ok(event) => {
+                        if event.kind.is_remove() {
+                            for path in &event.paths {
+                                let res = watcher.watch(path, RecursiveMode::NonRecursive);
+                                if let Err(error) = res {
+                                    tracing::error!(%error, path = %path.display(), "Failed to re-watch file");
+                                }
+                            }
+                        }
+                        (self.handler)(event).await;
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, "Failed to watch files");
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod filewatcher;
 pub mod handler;
 pub mod leader_election;
 pub mod reconcile;

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -21,8 +21,9 @@ use crate::{
     types::rule::{MutatingRule, ValidatingRule},
 };
 
-const VALIDATINGRULE_OWNED_LABEL_KEY: &str = "checkpoint.devsisters.com/validatingrule";
-const MUTATINGRULE_OWNED_LABEL_KEY: &str = "checkpoint.devsisters.com/mutatingrule";
+pub const VALIDATINGRULE_OWNED_LABEL_KEY: &str = "checkpoint.devsisters.com/validatingrule";
+pub const MUTATINGRULE_OWNED_LABEL_KEY: &str = "checkpoint.devsisters.com/mutatingrule";
+pub const SHOULD_UPDATE_ANNOTATION_KEY: &str = "checkpoint.devsisters.com/should-update";
 
 pub struct ReconcilerContext {
     pub client: kube::Client,


### PR DESCRIPTION
## Problem

- TLS cert and key for webhook are not appropriately reloaded.
- TLS CA bundle for {Validating,Mutating}WebhookConfiguration is not reloaded at all.

## Solution

- Update reloader with proper filewatcher implementation.
  - The new filewatcher works the same as Go's certwatcher in controller-runtime
- Add reloader for CA bundle

## TODOs

- The filewatcher implementation is not perfect. It cannot follow a new symlink if the original symlink is not removed.
- Currently, the webhook and controller are separate pods, so their reloading timing can vary.