### PR TITLE
Make CA duration extremely long

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -60,6 +60,10 @@ app.kubernetes.io/component: controller
 app.kubernetes.io/component: webhook
 {{- end }}
 
-{{- define "checkpoint.issuerName" -}}
+{{- define "checkpoint.selfSignedIssuerName" -}}
 {{ include "checkpoint.fullname" . }}-selfsigned
+{{- end -}}
+
+{{- define "checkpoint.caIssuerName" -}}
+{{ include "checkpoint.fullname" . }}-ca
 {{- end -}}

--- a/helm/templates/cert.yaml
+++ b/helm/templates/cert.yaml
@@ -1,17 +1,31 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: {{ include "checkpoint.fullname" . }}-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "checkpoint.fullname" . }}-ca-cert
+  commonName: {{ include "checkpoint.fullname" . }}-ca
+  isCA: true
+  duration: 876000h # 100y
+  renewBefore: 360h # 15d
+  issuerRef:
+    name: {{ include "checkpoint.selfSignedIssuerName" . }}
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: {{ include "checkpoint.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   secretName: {{ include "checkpoint.fullname" . }}-cert
   commonName: {{ printf "%s-webhook" (include "checkpoint.fullname" .) }}
   dnsNames:
-    - {{ printf "%s-webhook.%s" (include "checkpoint.fullname" .) .Release.Namespace }}
-    - {{ printf "%s-webhook.%s.svc" (include "checkpoint.fullname" .) .Release.Namespace }}
-  isCA: true
+  - {{ printf "%s-webhook.%s" (include "checkpoint.fullname" .) .Release.Namespace }}
+  - {{ printf "%s-webhook.%s.svc" (include "checkpoint.fullname" .) .Release.Namespace }}
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   issuerRef:
-    name: {{ include "checkpoint.issuerName" . }}
+    name: {{ include "checkpoint.caIssuerName" . }}
     kind: Issuer

--- a/helm/templates/issuer.yaml
+++ b/helm/templates/issuer.yaml
@@ -1,7 +1,16 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "checkpoint.issuerName" . }}
+  name: {{ include "checkpoint.selfSignedIssuerName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "checkpoint.caIssuerName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ include "checkpoint.fullname" . }}-ca-cert


### PR DESCRIPTION
There is a problem when the certificate is expired and reloaded.

There is a brief time when `{Validation,Mutating}WebhookConfiguration`'s `caBundle` and the webhook server's serving certificate do not match.

This PR extends CA's duration to extremely long, so `caBundle` will not likely be changed.