### PR TITLE
Pin toolchain to 1.71.1

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -1,6 +1,7 @@
 name: clippy
 
 on:
+  push:
   pull_request:
 
 jobs:
@@ -8,13 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@1.71.1
       with:
-        profile: minimal
-        toolchain: stable
         components: clippy
-    - uses: Swatinem/rust-cache@v2
-    - uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --no-deps --all-targets -- -D warnings
+    - run: cargo clippy --no-deps --all-targets -- -D warnings

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -1,7 +1,6 @@
 name: clippy
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/crdgen.yaml
+++ b/.github/workflows/crdgen.yaml
@@ -1,7 +1,6 @@
 name: crdgen
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/crdgen.yaml
+++ b/.github/workflows/crdgen.yaml
@@ -1,6 +1,7 @@
 name: crdgen
 
 on:
+  push:
   pull_request:
 
 jobs:
@@ -8,10 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+    - uses: dtolnay/rust-toolchain@1.71.1
     - uses: Swatinem/rust-cache@v2
     - name: Check crdgen diff
       run: cargo run --bin crdgen | diff helm/templates/crds/customresourcedefinition.yaml -

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -1,6 +1,7 @@
 name: rustfmt
 
 on:
+  push:
   pull_request:
 
 jobs:
@@ -8,13 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@1.71.1
       with:
-        profile: minimal
-        toolchain: stable
         components: rustfmt
-    - name: Check rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
+    - run: cargo fmt --check

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -1,7 +1,6 @@
 name: rustfmt
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: test
 
 on:
+  push:
   pull_request:
 
 jobs:
@@ -8,24 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+    - uses: dtolnay/rust-toolchain@1.71.1
     - uses: Swatinem/rust-cache@v2
-    - name: Run test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
+    - run: cargo test
 
   example-testcases:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+    - uses: dtolnay/rust-toolchain@1.71.1
     - uses: Swatinem/rust-cache@v2
     - name: Run example testcases
       run: cargo run --bin checkpoint -- test $(find -type f -iname testcase.yaml)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,6 @@
 name: test
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = { version = "1.0.68", features = ["backtrace"] }
 axum = "0.6.1"
 axum-server = { version = "0.4.4", features = ["tls-rustls"] }
 chrono = "0.4.23"
-clap = { version = "4.0.30", features = ["derive"] }
+clap = { version = "=4.0.30", features = ["derive"] }
 deno_core = "0.191.0"
 envy = "0.4.2"
 futures-util = "0.3.25"
@@ -19,10 +19,10 @@ interpolator = "0.5.0"
 itertools = "0.10.5"
 json-patch = "1.0.0"
 k8s-openapi = { version = "0.18.0", features = ["v1_21", "schemars"] }
-kube = { version = "0.82.2", default-features = false, features = ["rustls-tls", "client", "derive", "runtime", "admission"] }
+kube = { version = "=0.82.2", default-features = false, features = ["rustls-tls", "client", "derive", "runtime", "admission"] }
 # default-features is disabled for tokio compatibility.
 # See https://docs.rs/notify/latest/notify/#crossbeam-channel--tokio
-notify = { version = "5.0.0", default-features = false }
+notify = { version = "5.0.0", default-features = false, features = ["macos_kqueue"] }
 once_cell = "1.16.0"
 reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls", "json"] }
 schemars = { version = "0.8.11", features = ["url"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.71.1"
+components = ["rustfmt", "clippy", "rustc"]


### PR DESCRIPTION
- Explicitly set toolchain to be `1.71.1` as compiles fail on the latest toolchain
- Use `dtolnay/rust-toolchain@1.71.1` for setting up toolchain in CI